### PR TITLE
Fix: fix the problem that the window cannot be maximized

### DIFF
--- a/src/server/seat_interface.h
+++ b/src/server/seat_interface.h
@@ -707,6 +707,7 @@ Q_SIGNALS:
     void hasKeyboardChanged(bool);
     void hasTouchChanged(bool);
     void pointerPosChanged(const QPointF &pos);
+    void windowPosChanged();
     void touchMoved(qint32 id, quint32 serial, const QPointF &globalPosition);
     void timestampChanged(quint32);
 


### PR DESCRIPTION
Need to resend the mouse position to the application when the window changed.
When switching from the maximized to the right split screen and again, the mouse position does not change, only the press event is reported. Since the window has changed, the relative coordinates are invalid and no response is made.

Log: fix the problem that the window cannot be maximized
Task: https://pms.uniontech.com/zentao/bug-view-122483.html
Change-Id: I722de060f19d808a174b290f5d05ddf1bd312941
Signed-off-by: zhang qiyi <zhangqiyi@uniontech.com>